### PR TITLE
Add PowerShell CI to Bowling Game Project

### DIFF
--- a/.github/workflows/powershell-actions.yml
+++ b/.github/workflows/powershell-actions.yml
@@ -1,0 +1,18 @@
+name: PowerShell Unit Tests on Ubuntu
+on:
+  push:
+    paths:
+      - '.github/workflows/powershell-actions.yml'  # This workflow
+      - '**.ps1'
+
+jobs:
+  pester-test:
+    name: Run PowerShell Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Run all Unit Tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Path ./* -Passthru

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bowling game example implemented with PowerShell and the Pester TDD framework.
 
 Testing
 
-[![Test PowerShell on Ubuntu](https://github.com/daveboster/azure-powershell/actions/workflows/powershell-actions.yml/badge.svg)](https://github.com/daveboster/azure-powershell/actions/workflows/powershell-actions.yml)
+[![Test PowerShell on Ubuntu](https://github.com/daveboster/bowling-game-powershell/actions/workflows/powershell-actions.yml/badge.svg)](https://github.com/daveboster/bowling-game-powershell/actions/workflows/powershell-actions.yml)
 
 ## CI/CD for PowerShell
 How can we do a CI/CD for PowerShell scripts?


### PR DESCRIPTION

Add Continuous Integration (CI) to the project to ensure passing unit tests outside of local developer environments.
- [X] Add CI to PowerShell on Ubuntu 
- [X] Add CI Badge on Readme

## Actions Now Show Test Runs
![image](https://user-images.githubusercontent.com/8752215/189941715-66fde116-ff4a-4b63-bd7a-251b972df75a.png)

![image](https://user-images.githubusercontent.com/8752215/189941971-9bb1dea4-d261-419d-bca7-bc4880ec60cd.png)

